### PR TITLE
Update ruby depency text from 2.0.0 to 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ bug-free or reliable. Take care!
 
 For using ltx2any without any bells and whistles, you should have
 
- * Ruby 2.0.0 or higher and
+ * Ruby 2.2.0 or higher and
  * LaTeX and friends.
 
 Any of the major (La)TeX distributions should provide the binaries you need.


### PR DESCRIPTION
When using `-d`, ltx2any relies on the listen gem, which requires Ruby 2.2.0 or higher. Therefore, I thought, it is a good idea to point out that dependency in the README.md